### PR TITLE
Redefine MouseEvent for server side rendering with Angular Universal.

### DIFF
--- a/src/scrollTo.ts
+++ b/src/scrollTo.ts
@@ -1,4 +1,8 @@
 import { Directive, ElementRef, Input, HostListener } from '@angular/core';
+
+declare let global:any;
+const MouseEvent = (global as any).MouseEvent as MouseEvent;
+
 @Directive({
   selector: '[scrollTo]'
 })


### PR DESCRIPTION
### Redefine MouseEvent for server side rendering with Angular Universal. 

* When AoT'ing and rendering on the server module, the DOM isn't present and fails to find MouseEvent, and causes any page to use this to not render. When running with the JiT or AoT'd code with a dom, this uses the correct event. 
* This trick was used by https://github.com/valor-software/ngx-bootstrap 